### PR TITLE
Add feature to discover running tauri app and attach to pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ node_modules/
 package-lock.json
 server/node_modules/
 server/package-lock.json
+.serena/

--- a/server/index.js
+++ b/server/index.js
@@ -189,6 +189,25 @@ const tools = [
       },
       required: ['process_id', 'command_name']
     }
+  },
+  {
+    name: 'find_running_apps',
+    description: 'Find running Tauri applications on the system',
+    inputSchema: {
+      type: 'object',
+      properties: {}
+    }
+  },
+  {
+    name: 'attach_to_app',
+    description: 'Attach to an already running Tauri application by PID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pid: { type: 'number', description: 'Process ID of the running app' }
+      },
+      required: ['pid']
+    }
   }
 ];
 


### PR DESCRIPTION
This pull request adds the ability to discover and attach to running Tauri applications by PID.

## Overview

This update introduces two features to the project:
 • Discovery of running Tauri applications on the system
 • Ability to attach to an already running Tauri application by its process ID (PID)

## Key Changes

1. New Tool Methods
 • Added two new tool methods in ‎⁠server/index.js⁠:
 ▫ ‎⁠find_running_apps⁠: Finds running Tauri applications on the system.
 ▫ ‎⁠attach_to_app⁠: Attaches to an already running Tauri application using its PID.

2. Rust Backend Enhancements (‎⁠src/tools/process.rs⁠)
 • ProcessInfo Struct:
 ▫ Added ‎⁠is_attached⁠ flag to distinguish between processes started by the tool and those attached externally.
 ▫ Changed ‎⁠child⁠ from a required field to an ‎⁠Option<Child>⁠ to support attached processes that don’t have a child process handle.
 • Process Management:
 ▫ Updated logic to prevent killing processes that were not started by the tool (i.e., attached processes).
 ▫ Added ‎⁠find_running_apps⁠ method to scan system processes and identify likely Tauri apps by name or command-line arguments.
 ▫ Added ‎⁠attach_to_app⁠ method to allow tracking and interacting with an existing process by PID, even if it wasn’t started by the tool.

3. Server Integration (‎⁠src/server.rs⁠)
 • Registered the new tool methods (‎⁠find_running_apps⁠, ‎⁠attach_to_app⁠) in the server’s method list and JSON-RPC interface.
 • Implemented handlers for these methods, including input validation and error handling.
 • Updated the tool listing to include the new methods and their input schemas.


## Summary

With these changes, users can now:
 • List all running Tauri applications on their system.
 • Attach to any of these running applications by specifying its PID, allowing for monitoring or interaction even if the process was not started by this tool.

These features improve the flexibility and usability of the tool for managing Tauri applications.